### PR TITLE
Couple small config fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -375,8 +375,7 @@ def archive_cold_objects(data, context):
         config = build_config()
         # set level at root logger
         if hasattr(logging, config.get('LOG_LEVEL')):
-            logging.getLogger("smart_archiver").setLevel(
-                getattr(logging, config.get('LOG_LEVEL')))
+            LOG.setLevel(getattr(logging, config.get('LOG_LEVEL')))
         else:
             print("Invalid log level specified: {}".format(
                 config.get('LOG_LEVEL')))

--- a/main.py
+++ b/main.py
@@ -331,8 +331,9 @@ def evaluate_objects(config):
 
 
 def find_config_file(args):
-    if args.config_file:
-        return args.config_file
+    if hasattr(args, 'config_file'):
+        if args.config_file:
+            return args.config_file
     elif getenv("SMART_ARCHIVE_CONFIG"):
         return getenv("SMART_ARCHIVE_CONFIG")
     return "./default.cfg"


### PR DESCRIPTION
Avoids an error if no `--config_file` flag has been provided and ensures the default logger object loglevel is set regardless of what it is named.