### PR TITLE
error handling improvements

### DIFF
--- a/gcs_sa/actions/__init__.py
+++ b/gcs_sa/actions/__init__.py
@@ -20,7 +20,8 @@ import time
 from datetime import datetime, timezone
 
 from google.api_core.exceptions import (NotFound, ServiceUnavailable,
-                                        TooManyRequests)
+                                        TooManyRequests, GatewayTimeout,
+                                        InternalServerError, BadGateway)
 from google.cloud import storage
 from google.cloud.bigquery import Row
 
@@ -53,6 +54,11 @@ def rewrite_object(row: Row, storage_class: str, moved_output: BigQueryOutput,
     max_retries = 10
 
     bucket_name, object_name = get_bucket_and_object(row.resourceName)
+
+    if None in (bucket_name, object_name):
+        LOG.error("Unable to determine bucket and object name for row with resourceName: {}. Skipping.".format(row.resourceName))
+        return
+
     object_path = "/".join(["gs:/", bucket_name, object_name])
 
     retry_delay = 0
@@ -67,7 +73,7 @@ def rewrite_object(row: Row, storage_class: str, moved_output: BigQueryOutput,
             if record_original_create_time and not dry_run:
                 # Get the blob info. Skip this on a dry run, as it creates
                 # an access record.
-                LOG.debug("Getting original blob info.")
+                LOG.debug("Getting original blob info for object {} in bucket {}.".format(object_name, bucket_name))
                 blob_info = bucket.get_blob(object_name)
                 current_create_time = blob_info.time_created \
                     if blob_info else None
@@ -93,7 +99,7 @@ def rewrite_object(row: Row, storage_class: str, moved_output: BigQueryOutput,
             LOG.info("%s object move record queued for write to BQ: \n%s",
                      object_path, object_info)
 
-        except (ServiceUnavailable, TooManyRequests):
+        except (ServiceUnavailable, TooManyRequests, InternalServerError, BadGateway):
             retry_count += 1
             if retry_count >= max_retries:
                 LOG.exception(

--- a/gcs_sa/bq/utils.py
+++ b/gcs_sa/bq/utils.py
@@ -33,4 +33,8 @@ def get_bucket_and_object(resource_name: str) -> Tuple[str, str]:
     bucket_name = pathparts[0]
     object_name = pathparts[1].split("objects/", 1)[1]
 
+    if object_name.endswith("/"):
+        # can happen when catch up table has been populated naively
+        object_name = None
+
     return (bucket_name, object_name)


### PR DESCRIPTION
Add a couple more common retryable exceptions to the retry logic and avoid trying to fetch gcs objects with invalid names.

Invalid names are the result of catchup_table records like these:

![image](https://user-images.githubusercontent.com/4367945/68244254-a7349680-ffd1-11e9-8eb9-7e88f5495275.png)
