### PR TITLE
subclassed TPE to modify with a bounded work queue

### DIFF
--- a/gcs_sa/__main__.py
+++ b/gcs_sa/__main__.py
@@ -61,6 +61,7 @@ def evaluate_objects() -> None:
         TableDefinitions.OBJECTS_MOVED))
     excluded_output = BigQueryOutput(get_table(
         TableDefinitions.OBJECTS_EXCLUDED))
+    rows_read = 0
 
     # Create temp table object. Doesn't need to be initialized.
     temp_table = Table("smart_archiver_temp")
@@ -76,10 +77,8 @@ def evaluate_objects() -> None:
         LOG.info("%s rows read.", rows_read)
         LOG.info(moved_output.stats())
         LOG.info(excluded_output.stats())
-
     register(cleanup)
 
-    rows_read = 0
     # Run query job
     job = run_query_job(compose_access_query(),
                         temp_table.get_fully_qualified_name())

--- a/gcs_sa/__main__.py
+++ b/gcs_sa/__main__.py
@@ -18,8 +18,9 @@ import logging
 import warnings
 import sys
 from atexit import register
-from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
+
+from google.cloud.bigquery import Row
 
 from gcs_sa.actions import rewrite_object
 from gcs_sa.args import get_args
@@ -29,6 +30,7 @@ from gcs_sa.bq.tables import Table, TableDefinitions, get_table
 from gcs_sa.config import config_to_string, get_config
 from gcs_sa.decisions import should_cool_down, should_warm_up
 from gcs_sa.logging import set_program_log_level
+from gcs_sa.thread import BoundedThreadPoolExecutor
 
 warnings.filterwarnings(
     "ignore", "Your application has authenticated using end user credentials")
@@ -59,7 +61,6 @@ def evaluate_objects() -> None:
         TableDefinitions.OBJECTS_MOVED))
     excluded_output = BigQueryOutput(get_table(
         TableDefinitions.OBJECTS_EXCLUDED))
-    work_queue = Queue(maxsize=3000)
 
     # Create temp table object. Doesn't need to be initialized.
     temp_table = Table("smart_archiver_temp")
@@ -84,33 +85,21 @@ def evaluate_objects() -> None:
                         temp_table.get_fully_qualified_name())
 
     # evaluate, archive and record
-    def archive_worker(name: str) -> None:
-        LOG.debug("Worker %s started.", name)
-        while True:
-            row = work_queue.get()
-            if not row:
-                break
-            if should_warm_up(row):
-                rewrite_object(row, 'STANDARD', moved_output,
-                               excluded_output)
-            elif should_cool_down(row):
-                rewrite_object(row, cold_storage_class,
-                               moved_output, excluded_output)
-        LOG.debug("Worker %s finished.", name)
+    def archive_worker(row: Row) -> None:
+        if should_warm_up(row):
+            rewrite_object(row, 'STANDARD', moved_output,
+                            excluded_output)
+        elif should_cool_down(row):
+            rewrite_object(row, cold_storage_class,
+                            moved_output, excluded_output)
 
 
     workers = config.getint('RUNTIME', 'WORKERS')
-    with ThreadPoolExecutor(max_workers=workers) as executor:
+    with BoundedThreadPoolExecutor(max_workers=workers) as executor:
         # Start all worker threads
-        for worker_name in range(workers):
-            executor.submit(archive_worker, worker_name)
-        # Enqueue all work
         for row in job.result():
             rows_read += 1
-            work_queue.put(row)
-        # Signal completion to all workers
-        for _ in range(workers):
-            work_queue.put(None)
+            executor.submit(archive_worker, row)
 
 
 if __name__ == "__main__":

--- a/gcs_sa/thread.py
+++ b/gcs_sa/thread.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Custom threading code.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
+
+class BoundedThreadPoolExecutor(ThreadPoolExecutor):
+    """A wrapper around concurrent.futures.thread.py to add a bounded
+    queue to ThreadPoolExecutor.
+    """
+    def __init__(self, *args, **kwargs):
+        """Construct a slightly modified ThreadPoolExecutor with a 
+        bounded queue for work. Causes submit() to block when full.
+
+        Arguments:
+            ThreadPoolExecutor {[type]} -- [description]
+        """
+        super().__init__(*args, **kwargs)
+        self._work_queue = Queue(1000)


### PR DESCRIPTION
Added a subclass called BoundedThreadPoolExecutor which modifies ThreadPoolExecutor very slightly, namely at [this line](https://github.com/python/cpython/blob/3.7/Lib/concurrent/futures/thread.py#L135). By switching from a SimpleQueue to a Queue(1000), calls to Executor.submit() should block when the queue is full. 

This allows a simple implementation where the results from the BigQuery job can be iterated upon and submitted as work, without worrying about the results streaming in faster than the work going out and causing out-of-control memory consumption.