### PR TITLE
allow configuration of temp table for sharding

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -53,6 +53,12 @@ WARM_THRESHOLD_ACCESSES=10
 # The dataset to use for storing audit logs and smart archive data.
 DATASET_NAME=CONFIGURE_ME
 
+# Set the name of the temporary table for query results. A temporary table is 
+# required because often the result set is too large to stream directly. You 
+# *must* set this variable if you are running multiple instances of this 
+# archiver using the same dataset for sharding or other reasons.
+# TEMP_TABLE=smart_archiver_temp
+
 # A catch-up table to use with object names and create times. This is useful for migrating objects which were created before audit logs were turned on. This data will be merged with the access logs so objects that are "hot" in this table will still be recognized as such.
 # CATCHUP_TABLE=bucket_metadata
 

--- a/gcs_sa/__main__.py
+++ b/gcs_sa/__main__.py
@@ -61,8 +61,10 @@ def evaluate_objects() -> None:
         TableDefinitions.OBJECTS_EXCLUDED))
     work_queue = Queue(maxsize=3000)
 
-    # Create temp table object. Doesn't need to be initialized.
-    temp_table = Table("smart_archiver_temp")
+    # Create temp table object. Doesn't need to be initialized, as the 
+    # query job will do that.
+    temp_table = Table(
+        config.get('BIGQUERY', 'TEMP_TABLE', fallback='smart_archiver_temp'))
 
     # Register cleanup as shutdown hook
     def cleanup():


### PR DESCRIPTION
If you run multiple instances of this using the same dataset, being able to set the temp table name is critical.

This was a TODO that got overlooked slightly too long... 