### PR TITLE
log object name when unhandled api exception happens

### DIFF
--- a/gcs_sa/actions/__init__.py
+++ b/gcs_sa/actions/__init__.py
@@ -115,7 +115,7 @@ def rewrite_object(row: Row, storage_class: str, moved_output: BigQueryOutput,
             retry_count += 1
             if retry_count >= max_retries:
                 LOG.exception(
-                    "%s failed! API error while updating storage class.")
+                    "API error while updating storage class for object {}.".format(object_path))
                 break
             retry_delay += backoff_seconds
             time.sleep(retry_delay)


### PR DESCRIPTION
Noticed a spate of exceptions which could not be retried recently, this helps diagnose these events.