### PR TITLE
avoid temp table name collision

### DIFF
--- a/gcs_sa/cli/cooldown.py
+++ b/gcs_sa/cli/cooldown.py
@@ -45,7 +45,7 @@ def cooldown_command() -> None:
     # Create temp table object. Doesn't need to be initialized, as the
     # query job will do that.
     temp_table = Table(
-        config.get('BIGQUERY', 'TEMP_TABLE', fallback='smart_archiver_temp'))
+        config.get('BIGQUERY', 'TEMP_TABLE', fallback='smart_archiver_temp_cooldown'))
 
     # Register cleanup as shutdown hook
     def cleanup():

--- a/gcs_sa/cli/warmup.py
+++ b/gcs_sa/cli/warmup.py
@@ -45,7 +45,7 @@ def warmup_command() -> None:
     # Create temp table object. Doesn't need to be initialized, as the
     # query job will do that.
     temp_table = Table(
-        config.get('BIGQUERY', 'TEMP_TABLE', fallback='smart_archiver_temp'))
+        config.get('BIGQUERY', 'TEMP_TABLE', fallback='smart_archiver_temp_warmup'))
 
     # Register cleanup as shutdown hook
     def cleanup():


### PR DESCRIPTION
Ran into a `google.api_core.exceptions.NotFound` exception while running both warmup and cooldown jobs simultaneously when one finished before the other taking the shared temp table with it. This should avoid that happening.