### PR TITLE
Feature/build catchup

### DIFF
--- a/gcs_sa/__init__.py
+++ b/gcs_sa/__init__.py
@@ -99,14 +99,25 @@ def warmup(context: object) -> None:
 
 
 @main.command()
+@click.option(
+    '-p',
+    '--prefix',
+    required=False,
+    help=
+    "A prefix to restrict the bucket listing(s) by. This is useful if you have"
+    "a very large bucket and want to shard the listing work.",
+    default=None)
 @click.argument('buckets', nargs=-1, required=False, default=None)
 @click.pass_context
-def catchup(context: object, buckets: [str] = None) -> None:
+def catchup(context: object, buckets: [str] = None, prefix: str = None) -> None:
     """
-    Build the catchup table with all objects in your bucket(s).
+    Build the catchup table with all objects in your bucket(s). The table will
+    be named whatever you set to the CATCHUP_TABLE value in the configuration
+    file. The table will be created if not found. If it is found, records will
+    be appended.
 
-    Optionally, provide a list of buckets (without gs://) to limit the scope
-    to. By default, all buckets in the configured project will be processed
+    Optionally, you can provide a list of buckets (without gs://) to limit the
+    scope. By default, all buckets in the configured project will be processed
     into the table.
 
     This listing of objects can be UNIONed with the access log by setting the
@@ -115,7 +126,7 @@ def catchup(context: object, buckets: [str] = None) -> None:
     access. If the object is in the access log, it will be processed as usual.
     """
     init(**context.obj)
-    return catchup_command(buckets)
+    return catchup_command(buckets, prefix)
 
 
 if __name__ == "__main__":

--- a/gcs_sa/__init__.py
+++ b/gcs_sa/__init__.py
@@ -19,8 +19,9 @@ import logging
 import warnings
 import click
 
-from gcs_sa.config import config_to_string, get_config
+from gcs_sa.config import config_to_string, set_config
 from gcs_sa.utils import set_program_log_level
+from gcs_sa.cli.catchup import catchup_command
 from gcs_sa.cli.cooldown import cooldown_command
 from gcs_sa.cli.doboth import doboth_command
 from gcs_sa.cli.warmup import warmup_command
@@ -43,40 +44,78 @@ LOG = logging.getLogger(__name__)
               required=False,
               help="Set log level. Overrides configuration.",
               default=None)
-def main(config_file: str = "./default.cfg", log_level: str = None) -> None:
+@click.pass_context
+def main(context: object = object(), **kwargs) -> None:
     """
     Smart archiver for GCS, which moves objects to storage classes based
     on access patterns to optimize for cost.
     """
-    config = get_config(config_file)
+    context.obj = kwargs
+
+
+def init(config_file: str = "./default.cfg", log_level: str = None) -> None:
+    """
+    Top-level initialization.
+
+    Keyword Arguments:
+        config_file {str} -- Path to config file. (default: {"./default.cfg"})
+        log_level {str} -- Desired log level. (default: {None})
+    """
+    config = set_config(config_file)
     print("Configuration parsed: \n{}".format(config_to_string(config)))
     set_program_log_level(log_level, config)
 
 
 @main.command()
-def cooldown():
+@click.pass_context
+def cooldown(context: object) -> None:
     """
     Process cool-down evaluations. A query will be done to only
     find cool-down candidate objects.
     """
+    init(**context.obj)
     return cooldown_command()
 
 
 @main.command()
-def doboth():
+@click.pass_context
+def doboth(context: object) -> None:
     """
     Process both warm-up and cool-down evaluations for all objects.
     """
+    init(**context.obj)
     return doboth_command()
 
 
 @main.command()
-def warmup():
+@click.pass_context
+def warmup(context: object) -> None:
     """
     Process warm-up evaluations. A query will be done to only
     find warm-up candidate objects.
     """
+    init(**context.obj)
     return warmup_command()
+
+
+@main.command()
+@click.argument('buckets', nargs=-1, required=False, default=None)
+@click.pass_context
+def catchup(context: object, buckets: [str] = None) -> None:
+    """
+    Build the catchup table with all objects in your bucket(s).
+
+    Optionally, provide a list of buckets (without gs://) to limit the scope
+    to. By default, all buckets in the configured project will be processed
+    into the table.
+
+    This listing of objects can be UNIONed with the access log by setting the
+    CATCHUP_TABLE value in the configuration file. If an object
+    is only in the catchup table, its create date will be treated as last
+    access. If the object is in the access log, it will be processed as usual.
+    """
+    init(**context.obj)
+    return catchup_command(buckets)
 
 
 if __name__ == "__main__":

--- a/gcs_sa/bq/output.py
+++ b/gcs_sa/bq/output.py
@@ -34,7 +34,7 @@ class BigQueryOutput():
     A queue-like output stream to a BigQuery table.
     """
 
-    def __init__(self, table: Table):
+    def __init__(self, table: Table, create_table: bool = True):
         self.config = get_config()
         self.lock = Lock()
         self.client = get_bq_client()
@@ -43,7 +43,8 @@ class BigQueryOutput():
         self.batch_size = int(
             self.config.get('BIGQUERY', 'BATCH_WRITE_SIZE', fallback=100))
         self.insert_count = 0
-        table.initialize()
+        if create_table:
+            table.initialize()
 
     def put(self, row) -> None:
         """

--- a/gcs_sa/cli/catchup.py
+++ b/gcs_sa/cli/catchup.py
@@ -1,0 +1,112 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Implementation of "catchup" command.
+"""
+
+import logging
+from configparser import ConfigParser
+
+from google.cloud.storage import Bucket, Client
+from google.api_core.page_iterator import Page
+
+from gcs_sa.bq.output import BigQueryOutput
+from gcs_sa.bq.tables import TableDefinitions, get_table
+from gcs_sa.config import get_config
+from gcs_sa.gcs.client import get_gcs_client
+from gcs_sa.thread import BoundedThreadPoolExecutor
+
+LOG = logging.getLogger(__name__)
+
+
+def catchup_command(buckets: [str] = None) -> None:
+    """Implementation of the catchup command.
+    
+    Keyword Arguments:
+        buckets {[type]} -- A list of buckets to use instead of the
+        project-wide bucket listing. (default: {None})
+    """
+    config = get_config()
+    gcs = get_gcs_client()
+    # Call this once to initialize.
+    _ = BigQueryOutput(
+        get_table(TableDefinitions.CATCHUP_TABLE,
+                  config.get("BIGQUERY", "CATCHUP_TABLE")))
+
+    # if buckets is given, get each bucket object; otherwise, list all bucket
+    # objects
+    if buckets:
+        buckets = [gcs.get_bucket(x) for x in buckets]
+    else:
+        buckets = [x for x in gcs.list_buckets()]
+
+    total_buckets = len(buckets)
+    buckets_listed = 0
+    bucket_blob_counts = dict()
+
+    workers = max(config.getint('RUNTIME', 'WORKERS') / 2, 1)
+    with BoundedThreadPoolExecutor(max_workers=workers) as executor:
+        for bucket in buckets:
+            buckets_listed += 1
+            executor.submit(bucket_lister, config, gcs, bucket, buckets_listed,
+                            total_buckets, bucket_blob_counts)
+
+
+def page_outputter(config: ConfigParser, bucket: Bucket, page: Page,
+                   stats: dict) -> None:
+    """Write a page of blob listing to BigQuery.
+
+    Arguments:
+        config {ConfigParser} -- The program config.
+        bucket {Bucket} -- The bucket where this list page came from.
+        page {Page} -- The Page object from the listing.
+        stats {dict} -- A dictionary of bucket_name (str): blob_count (int)
+    """
+    catchup_output = BigQueryOutput(
+        get_table(TableDefinitions.CATCHUP_TABLE,
+                  config.get("BIGQUERY", "CATCHUP_TABLE")), False)
+    blob_count = 0
+
+    for blob in page:
+        blob_count += 1
+        metadata = blob.__dict__["_properties"]
+        catchup_output.put(metadata)
+
+    catchup_output.flush()
+    stats[bucket] += blob_count
+    LOG.info("%s blob records written for bucket %s.", stats[bucket], bucket)
+
+
+def bucket_lister(config: ConfigParser, gcs: Client, bucket: Bucket,
+                  bucket_number: int, total_buckets: int, stats: dict) -> None:
+    """List a bucket, sending each page of the listing into an executor pool
+    for processing.
+    
+    Arguments:
+        config {ConfigParser} -- The program config.
+        gcs {Client} -- A GCS client object.
+        bucket {Bucket} -- A GCS Bucket object to list.
+        bucket_number {int} -- The number of this bucket (out of the total).
+        total_buckets {int} -- The total number of buckets that will be listed.
+        stats {dict} -- A dictionary of bucket_name (str): blob_count (int)
+    """
+    LOG.info("Listing %s. %s of %s total buckets", bucket.name, bucket_number,
+             total_buckets)
+    stats[bucket] = 0
+
+    workers = max(config.getint('RUNTIME', 'WORKERS') / 2, 1)
+    with BoundedThreadPoolExecutor(max_workers=workers) as sub_executor:
+        blobs = gcs.list_blobs(bucket)
+        for page in blobs.pages:
+            sub_executor.submit(page_outputter, config, bucket, page, stats)

--- a/gcs_sa/config.py
+++ b/gcs_sa/config.py
@@ -36,26 +36,30 @@ class ConfigParserHolder():
 CONFIG_HOLDER = ConfigParserHolder()
 
 
-def get_config(config_file: str = None) -> ConfigParser:
-    """Get the configuration by locating a config file, and building a
-    configuration with items from these sources, in ascending priority:
+def set_config(config_file: str) -> ConfigParser:
+    """Set the configuration stored in this module.
 
-    * Program defaults
-    * The config file
-    * Command argument overrides, where permitted
-
-    The results of this function are memoized, so it can only be run once
-    per configuration file.
+    Arguments:
+        config_file {str} -- Path to the config file.
 
     Returns:
-        dict -- The final configuration values.
+        ConfigParser -- The stored parsed configuration.
     """
 
-    if not CONFIG_HOLDER.config:
-        config = ConfigParser()
-        config.read(config_file)
-        check_configured(config)
-        CONFIG_HOLDER.config = config
+    config = ConfigParser()
+    config.read(config_file)
+    check_configured(config)
+    CONFIG_HOLDER.config = config
+    return CONFIG_HOLDER.config
+
+
+def get_config() -> ConfigParser:
+    """Get the configuration stored in this module.
+
+    Returns:
+        ConfigParser -- The stored parsed configuration.
+    """
+
     return CONFIG_HOLDER.config
 
 


### PR DESCRIPTION
Add a feature to build a catchup table.

Previously this was handled via a script, which hadn't even been added to the repo yet.

The multiprocessing model is a little complex with two executors, however to pass a single executor around when threads in the executor are dispatching work into it presented scoping problems (e.g., the executor would be closed before any of the workers could submit anything). So it was easier to just do two executors and split the worker threads between them.

The parallelism model here tested much faster than anything else I tried. It will stream 100,000+ objects in a few 10s of seconds.