### PR TITLE
ignore our own GCS object accesses

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -17,6 +17,8 @@
 # The project in which to set up audit logging and perform smart archive work.
 PROJECT=CONFIGURE_ME
 
+# The full email address of the GCP Service Account this job will use for authentication.
+SVC_ACCOUNT=CONFIGURE_ME
 
 [RUNTIME]
 # Number of worker threads. Each thread will process one row from BigQuery at a time, serially performing decision and action functions.


### PR DESCRIPTION
Hi Dom, got a weird one here for you!

We found that for one particular bucket which had a lifecycle policy to push objects to nearline after 40 days we were seeing way more warmups than expected. Turns out that when cooling down objects over a certain filesize the `rewrite` method performs the copy operation [using concurrent requests under the hood](https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite). If the files are big enough this can push the number of object accesses over the warmup threshold so they're immediately brought back to standard causing a lot of churn.

This change allows us to ignore our own interactions with GCS when evaluating which objects to move.

May want to consider adding a note to the docs that this job should be run under it's own unique service account. If users shared service accounts between this and some other app interacting with GCS those accesses would be ignored as well.